### PR TITLE
Rtg 7653 - toggles arrow visibility at beginning and end of track

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtgdev/react-slick",
-  "version": "0.26.6",
+  "version": "0.26.7",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtgdev/react-slick",
-  "version": "0.26.7",
+  "version": "0.26.8",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtgdev/react-slick",
-  "version": "0.26.7-beta.0",
+  "version": "0.26.7",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtgdev/react-slick",
-  "version": "0.26.7",
+  "version": "0.26.7-beta.0",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtgdev/react-slick",
-  "version": "0.26.6",
+  "version": "0.26.6-beta.0",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtgdev/react-slick",
-  "version": "0.26.6-beta.0",
+  "version": "0.26.6",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -22,6 +22,7 @@ export class PrevArrow extends React.PureComponent {
     ) {
       prevClasses["slick-disabled"] = true;
       prevHandler = null;
+      return null;
     }
 
     let prevArrowProps = {
@@ -69,6 +70,7 @@ export class NextArrow extends React.PureComponent {
     if (!canGoNext(this.props)) {
       nextClasses["slick-disabled"] = true;
       nextHandler = null;
+      return null;
     }
 
     let nextArrowProps = {
@@ -82,7 +84,15 @@ export class NextArrow extends React.PureComponent {
       currentSlide: this.props.currentSlide,
       slideCount: this.props.slideCount
     };
+    // const {
+    //   currentSlide,
+    //   slideCount,
+    //   slidesToShow,
+    // } = this.props
+
     let nextArrow;
+
+    // if (currentSlide >= slideCount - slidesToShow) return null
 
     if (this.props.nextArrow) {
       nextArrow = React.cloneElement(this.props.nextArrow, {

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -4,6 +4,11 @@ import React from "react";
 import classnames from "classnames";
 import { canGoNext } from "./utils/innerSliderUtils";
 
+/**
+ * PrevArrow
+ * @param {boolean} arrowVisibleFlag Arrows are hidden when not possible to scroll further or previous
+ * @returns {JSX.Element} Returns null if arrowVisibleFlag is false
+ */
 export class PrevArrow extends React.PureComponent {
   clickHandler(options, e) {
     if (e) {
@@ -22,7 +27,7 @@ export class PrevArrow extends React.PureComponent {
     ) {
       prevClasses["slick-disabled"] = true;
       prevHandler = null;
-      return null;
+      if (!this.props.arrowVisibleFlag) return null;
     }
 
     let prevArrowProps = {
@@ -56,6 +61,12 @@ export class PrevArrow extends React.PureComponent {
   }
 }
 
+/**
+ * NextArrow
+ *
+ * @param {boolean} arrowVisibleFlag
+ * @returns {JSX.Element} returns null if arrowVisibleFlag false
+ */
 export class NextArrow extends React.PureComponent {
   clickHandler(options, e) {
     if (e) {
@@ -70,7 +81,7 @@ export class NextArrow extends React.PureComponent {
     if (!canGoNext(this.props)) {
       nextClasses["slick-disabled"] = true;
       nextHandler = null;
-      return null;
+      if (!this.props.arrowVisibleFlag) return null;
     }
 
     let nextArrowProps = {
@@ -84,15 +95,8 @@ export class NextArrow extends React.PureComponent {
       currentSlide: this.props.currentSlide,
       slideCount: this.props.slideCount
     };
-    // const {
-    //   currentSlide,
-    //   slideCount,
-    //   slidesToShow,
-    // } = this.props
 
     let nextArrow;
-
-    // if (currentSlide >= slideCount - slidesToShow) return null
 
     if (this.props.nextArrow) {
       nextArrow = React.cloneElement(this.props.nextArrow, {

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -6,6 +6,8 @@ import { canGoNext } from "./utils/innerSliderUtils";
 
 /**
  * PrevArrow
+ * Note that props originate in 'initial-state.js'
+ *
  * @param {boolean} arrowVisibleFlag Arrows are hidden when not possible to scroll further or previous
  * @returns {JSX.Element} Returns null if arrowVisibleFlag is false
  */

--- a/src/arrows.js
+++ b/src/arrows.js
@@ -6,10 +6,11 @@ import { canGoNext } from "./utils/innerSliderUtils";
 
 /**
  * PrevArrow
+ *
  * Note that props originate in 'initial-state.js'
  *
- * @param {boolean} arrowVisibleFlag Arrows are hidden when not possible to scroll further or previous
- * @returns {JSX.Element} Returns null if arrowVisibleFlag is false
+ * @param {boolean} autoHideArrow Arrows are hidden when not possible to scroll previous
+ * @returns {JSX.Element}
  */
 export class PrevArrow extends React.PureComponent {
   clickHandler(options, e) {
@@ -29,7 +30,7 @@ export class PrevArrow extends React.PureComponent {
     ) {
       prevClasses["slick-disabled"] = true;
       prevHandler = null;
-      if (!this.props.arrowVisibleFlag) return null;
+      if (this.props.autoHideArrow) return null;
     }
 
     let prevArrowProps = {
@@ -66,8 +67,8 @@ export class PrevArrow extends React.PureComponent {
 /**
  * NextArrow
  *
- * @param {boolean} arrowVisibleFlag
- * @returns {JSX.Element} returns null if arrowVisibleFlag false
+ * @param {boolean} autoHideArrow - hides arrow if you cannot click Next
+ * @returns {JSX.Element}
  */
 export class NextArrow extends React.PureComponent {
   clickHandler(options, e) {
@@ -83,7 +84,7 @@ export class NextArrow extends React.PureComponent {
     if (!canGoNext(this.props)) {
       nextClasses["slick-disabled"] = true;
       nextHandler = null;
-      if (!this.props.arrowVisibleFlag) return null;
+      if (this.props.autoHideArrow) return null;
     }
 
     let nextArrowProps = {

--- a/src/initial-state.js
+++ b/src/initial-state.js
@@ -21,7 +21,7 @@ const initialState = {
   touchObject: { startX: 0, startY: 0, curX: 0, curY: 0 },
   trackStyle: {},
   trackWidth: 0,
-  arrowVisibleFlag: false
+  autoHideArrow: true
 };
 
 export default initialState;

--- a/src/initial-state.js
+++ b/src/initial-state.js
@@ -20,7 +20,8 @@ const initialState = {
   swiping: false,
   touchObject: { startX: 0, startY: 0, curX: 0, curY: 0 },
   trackStyle: {},
-  trackWidth: 0
+  trackWidth: 0,
+  arrowVisibleFlag: false
 };
 
 export default initialState;

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -662,7 +662,8 @@ export class InnerSlider extends React.Component {
       "slideCount",
       "slidesToShow",
       "prevArrow",
-      "nextArrow"
+      "nextArrow",
+      "arrowVisibleFlag"
     ]);
     arrowProps.clickHandler = this.changeSlide;
 

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -663,7 +663,7 @@ export class InnerSlider extends React.Component {
       "slidesToShow",
       "prevArrow",
       "nextArrow",
-      "arrowVisibleFlag"
+      "autoHideArrow"
     ]);
     arrowProps.clickHandler = this.changeSlide;
 


### PR DESCRIPTION
Aka:

hide Previous arrow when user cannot precede as well as Next arrow when there are no more images to proceed towards.